### PR TITLE
Remove deprecated option from gemspec

### DIFF
--- a/url_shortener.gemspec
+++ b/url_shortener.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
              "lib/url_shortener/response/stats.rb",
              "lib/url_shortener/response/info.rb"
              ]
-  s.has_rdoc = true
   s.homepage = %q{http://github.com/nas/url_shortener}
   s.rdoc_options = ["--charset=UTF-8"]
   s.require_paths = ["lib"]


### PR DESCRIPTION
When bundling the gem:

```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /usr/local/Cellar/asdf/0.5.1/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/bundler/gems/url_shortener-fcf77f525510/url_shortener.gemspec:25.
```